### PR TITLE
Add option to preview full feed contents

### DIFF
--- a/rss.xsl
+++ b/rss.xsl
@@ -8,8 +8,9 @@
     xmlns:media="http://search.yahoo.com/mrss/"
     exclude-result-prefixes="atom atom03 rdf rss1 media" >
 
-    <xsl:output method="html" indent="yes" encoding="utf-8" />
+    <xsl:param name="fullPreview" />
 
+    <xsl:output method="html" indent="yes" encoding="utf-8" />
 
     <xsl:template match="channel | atom:feed | atom03:feed | rss1:channel">
 
@@ -58,7 +59,7 @@
                 <img class="mediaThumb" src="{ .//media:thumbnail/@url }" width="{ .//media:thumbnail/@width }" height="{ .//media:thumbnail/@height }" />
             </xsl:if>
             <xsl:choose>
-              <xsl:when test="atom:summary | atom03:summary">
+              <xsl:when test="not($fullPreview) and atom:summary | atom03:summary">
                 <div class="feedRawContent" desctype="{atom:summary/@type | atom03:summary/@type }">
                     <xsl:copy-of select="atom:summary | atom03:summary"  />
                 </div>

--- a/rsspreview.js
+++ b/rsspreview.js
@@ -18,6 +18,7 @@
     valMaxWidth: "900px",
     doDetect: false,
     preventPreview: false,
+    fullPreview: false,
     enableCss: false,
     customCss: null
   };
@@ -47,6 +48,7 @@
   function applyxsl(xmlin, xsl, node, doc = document) {
     let xsltProcessor = new XSLTProcessor();
     xsltProcessor.importStylesheet(xsl);
+    xsltProcessor.setParameter(null, 'fullPreview', options.fullPreview);
 
     let fragment = xsltProcessor.transformToFragment(xmlin, doc);
     node.appendChild(fragment);

--- a/settings/options.html
+++ b/settings/options.html
@@ -11,6 +11,8 @@
     <hr />
     <label class="setting browser-style"><input type="checkbox" id="preventPreview" class="validate" > Display raw xml instead of preview page</label>
     <hr />
+    <label class="setting browser-style"><input type="checkbox" id="fullPreview" class="validate" > Display full articles even when summaries are present</label>
+    <hr />
 
     <label class="setting browser-style"><input type="checkbox" id="doThumb" class="validate" > Display media:thumbnail images</label>
 

--- a/settings/options.js
+++ b/settings/options.js
@@ -8,6 +8,7 @@ function saveOptions(e) {
     valMaxWidth: document.querySelector("#valMaxWidth").value,
     doDetect: document.querySelector("#doDetect").checked,
     preventPreview: document.querySelector("#preventPreview").checked,
+    fullPreview: document.querySelector("#fullPreview").checked,
     enableCss: document.querySelector("#enableCss").checked,
     customCss: document.querySelector("#customCss").value
   });
@@ -23,6 +24,7 @@ function restoreOptions() {
     document.querySelector("#valMaxWidth").value = result.valMaxWidth;
     document.querySelector("#doDetect").checked = result.doDetect;
     document.querySelector("#preventPreview").checked = result.preventPreview;
+    document.querySelector("#fullPreview").checked = result.fullPreview;
     document.querySelector("#enableCss").checked = result.enableCss;
     document.querySelector("#customCss").value = result.customCss;
   }
@@ -37,6 +39,7 @@ function restoreOptions() {
     valMaxWidth: "900px",
     doDetect: false,
     preventPreview: false,
+    fullPreview: false,
     enableCss: false,
     customCss: null
   });


### PR DESCRIPTION
Currently, if a feed provides summaries of posts, it's not possible to
view the full content within the preview page. This change adds a new
option to choose between summary and full contents.