### PR TITLE
CSS: Declare text color to default black

### DIFF
--- a/preview.css
+++ b/preview.css
@@ -1,6 +1,7 @@
 html {
   font: 3mm tahoma,arial,helvetica,sans-serif;
   background-color: rgb(240, 240, 240);
+  color: rgb(0, 0, 0);
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Because background color is defined, the text may be not readable if users changed their default colors in the "Preferences" page of Firefox. So to ensure the text can be read if the defaults are changed, the text color too should be declared.