### PR TITLE
Improve YouTube feed detection

### DIFF
--- a/rsspreview.js
+++ b/rsspreview.js
@@ -379,10 +379,16 @@
   }
 
   function findYouTubeFeeds() {
-    let match = document.URL.match(/channel\/([a-zA-Z0-9_-]+)/);
-    if (match) {
+    // YouTube's canonical channel URLs look like /channel/AlphaNumericID
+    // It also supports named channels of the form /c/MyChannelName
+    // Match on both of these to autodetect channel feeds on either URL
+    let idPattern = /channel\/(?<channelId>[a-zA-Z0-9_-]+)/;
+    let namePattern = /c\/[a-zA-Z0-9_-]+/;
+    let urlPattern = new RegExp(`${idPattern.source}|${namePattern.source}`);
+    if (document.URL.match(urlPattern)) {
       let feeds = {};
-      let channelId = match[1];
+      let canonicalUrl = document.querySelector("link[rel='canonical']").href;
+      let channelId = canonicalUrl.match(idPattern).groups.channelId;
       let url = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
       let title = document.title;
       feeds[url] = title;


### PR DESCRIPTION
YouTube supports channels identified by both channel ID and channel
name. For example, https://www.youtube.com/c/dslrvideoshooter and
https://www.youtube.com/channel/UCMmA0XxraDP7ZVbv4eY3Omg are the same
channel, but the former has a more human-friendly URL. This change
allows the extension to detect the channel's RSS feed regardless of
which URL is loaded using the canonical link provided on each channel
page. This change is fully backward compatible.