### PR TITLE
Pass the opener tab ID to browser.tabs.create

### DIFF
--- a/background.js
+++ b/background.js
@@ -65,6 +65,7 @@ function handleMessage(request, sender, sendResponse) {
   browser.storage.sync.get({orangeIcon: false}).then(function(options){
 
     let popup = new URL(browser.runtime.getURL('popup/popup.html'));
+    popup.searchParams.set('tabId', sender.tab.id.toString());
     popup.searchParams.set('feeds', JSON.stringify(request));
 
     if (options.orangeIcon) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -19,6 +19,8 @@ document.addEventListener("DOMContentLoaded", function(event) {
   const feedList = document.getElementById('feedList');
 
   const url = new URL(location.href);
+  // `+` converts the string to an number
+  const tabId = +url.searchParams.get('tabId');
   const feeds = JSON.parse(url.searchParams.get('feeds'));
 
   for (feed_url in feeds) {
@@ -50,7 +52,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
       let url = elem.getAttribute("data-href");
       if (url) {
         if (options.newTab)
-          browser.tabs.create({url: url});
+          browser.tabs.create({url: url, openerTabId: tabId});
         else
           browser.tabs.update({url: url}).then(onUpdated, onError);
       }


### PR DESCRIPTION
This means that:
- the RSS preview tab opens in the same container in which the opener tab was open (without need for extra permissions);
- the RSS preview tab appears right next to the tab from which it was opened, not at the end of the tab bar; and
- if the user closes the tab without switching tabs between opening and closing the tab, Firefox activates the previous tab (i.e. from which the RSS preview was opened), not the next one.