### PR TITLE
CSS: dark mode

### DIFF
--- a/preview.css
+++ b/preview.css
@@ -169,3 +169,27 @@ img {
   padding-left: 5px;
   padding-top: 3px;
 }
+
+@media(prefers-color-scheme: dark){
+  html {
+    background-color: rgb(28, 27, 34);
+    color: white;
+  }
+  h1 {
+    border-color: rgba(249,249,250,0.2);
+  }
+  #feedBody {
+    border-color: rgba(249,249,250,0.2);
+    background-color: rgb(35, 34, 43);
+  }
+  #feedBody a {
+    color: rgb(0,221,255);
+  }
+  .link {
+    color: rgb(0,221,255);
+  }
+  .enclosures {
+    border-color: rgba(249,249,250,0.2);
+    background-color: rgb(28, 27, 34);
+  }
+}


### PR DESCRIPTION
I've added dark mode to the feed preview that respects browser settings.
Colors are the same (or similar) that Firefox uses in its own menus.